### PR TITLE
Adding "Volumes" property to Dockerrun.aws.jso

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -9,5 +9,9 @@
         "ContainerPort": "8000"
       }
     ],
+    "Volumes":
+    [
+
+    ],
     "Logging": "/var/log/nginx"
   }


### PR DESCRIPTION
The property is added in order to avoid `jq: error: Cannot iterate over null`. See: [this Stack Overflow answer](https://stackoverflow.com/questions/28213232/docker-error-jq-error-cannot-iterate-over-null#28302180).

Found in a running EB instance.